### PR TITLE
Add nvToolsExt library.

### DIFF
--- a/condarecipe8.0/meta.yaml
+++ b/condarecipe8.0/meta.yaml
@@ -3,7 +3,7 @@ package:
    version: 8.0
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -98,17 +98,18 @@ cu_8['installers_url_ext'] = 'local_installers/'
 cu_8['patch_url_ext'] = 'patches/2/'
 cu_8['md5_url'] = "https://developer.nvidia.com/compute/cuda/8.0/Prod2/docs/sidebar/md5sum-txt"
 cu_8['cuda_libraries'] = [
-    'cublas',
     'cudart',
     'cufft',
-    'curand',
+    'cublas',
     'cusparse',
     'cusolver',
+    'curand',
     'nppc',
     'nppi',
     'npps',
-    'nvrtc-builtins',
     'nvrtc',
+    'nvrtc-builtins',
+    'nvtoolsext',
 ]
 cu_8['libdevice_versions'] = ['20.10', '30.10', '35.10', '50.10']
 


### PR DESCRIPTION
This adds the nvToolsExt library to the package, reorders the
library listing for CUDA 8 to match that of the EULA, and bumps
the build number. There is a known issue with the windows 64bit
variant that requires additional work before a build can be made.