### PR TITLE
NvToolsExt fixes

### DIFF
--- a/condarecipe7.5/meta.yaml
+++ b/condarecipe7.5/meta.yaml
@@ -4,6 +4,8 @@ package:
 
 build:
   number: 3
+  script_env:
+    - NVTOOLSEXT_INSTALL_PATH
 
 requirements:
   build:

--- a/condarecipe8.0/meta.yaml
+++ b/condarecipe8.0/meta.yaml
@@ -4,6 +4,8 @@ package:
 
 build:
   number: 2
+  script_env:
+    - NVTOOLSEXT_INSTALL_PATH
 
 requirements:
   build:


### PR DESCRIPTION
This adds the environment variable "NVTOOLEXT_INSTALL_PATH" as
a pass through variable to the conda build scripts. This is to
accommodate the windows installers not having the nvtoolsext DLL
as an extractable item and allow assembly from an already present
installation, the location of the dll is not the install directory!