### PR TITLE
Support symlinked libraries on linux.

### DIFF
--- a/condarecipe8.0/meta.yaml
+++ b/condarecipe8.0/meta.yaml
@@ -3,7 +3,7 @@ package:
    version: 8.0
 
 build:
-  number: 2
+  number: 3
   script_env:
     - NVTOOLSEXT_INSTALL_PATH
 


### PR DESCRIPTION
This patch ensures that the nvToolsExt library symlinks are
included (and indeed all symlinks) for the CUDA toolkit 8
linux build. This is due to the SONAME not matching the DSO name.

Build number is bumped.