### PR TITLE
New modular build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 *.pyc
 src
+*~
+*.swp
+*.swo
+*.un

--- a/condarecipe7.5/meta.yaml
+++ b/condarecipe7.5/meta.yaml
@@ -3,7 +3,7 @@ package:
    version: 7.5
 
 build:
-  number: 3
+  number: 4
   script_env:
     - NVTOOLSEXT_INSTALL_PATH
 
@@ -14,9 +14,177 @@ requirements:
     - 7za # [win]
     - conda
     - pyyaml
+  run:
+    - cudart 7.5.*
+    - cublas 7.5.*
+    - cufft 7.5.*
+    - curand 7.5.*
+    - cusparse 7.5.*
+    - cusolver 7.5.*
+    - npp 7.5.*
+    - nvblas 7.5.*
+    - nvrtc 7.5.*
+    - nvvm 7.5.*
+    - cupti 7.5.*
+
+outputs:
+  - name: cudart
+    requirements:
+      build:
+        - python >=3
+        - requests
+        - 7za # [win]
+        - conda
+        - pyyaml
+    source:
+      path: ../scripts/
+    script: bld.bat # [win]
+    script: bld.sh # [not win]
+  - name: cublas
+    requirements:
+      build:
+        - python >=3
+        - requests
+        - 7za # [win]
+        - conda
+        - pyyaml
+      run:
+        - cudart 7.5.*
+    source:
+      path: ../scripts/
+    script: bld.bat # [win]
+    script: bld.sh # [not win]
+  - name: cufft
+    requirements:
+      build:
+        - python >=3
+        - requests
+        - 7za # [win]
+        - conda
+        - pyyaml
+      run:
+        - cudart 7.5.*
+    source:
+      path: ../scripts/
+    script: bld.bat # [win]
+    script: bld.sh # [not win]
+  - name: curand
+    requirements:
+      build:
+        - python >=3
+        - requests
+        - 7za # [win]
+        - conda
+        - pyyaml
+      run:
+        - cudart 7.5.*
+    source:
+      path: ../scripts/
+    script: bld.bat # [win]
+    script: bld.sh # [not win]
+  - name: cusparse
+    requirements:
+      build:
+        - python >=3
+        - requests
+        - 7za # [win]
+        - conda
+        - pyyaml
+      run:
+        - cudart 7.5.*
+    source:
+      path: ../scripts/
+    script: bld.bat # [win]
+    script: bld.sh # [not win]
+  - name: npp
+    requirements:
+      build:
+        - python >=3
+        - requests
+        - 7za # [win]
+        - conda
+        - pyyaml
+      run:
+        - cudart 7.5.*
+    source:
+      path: ../scripts/
+    script: bld.bat # [win]
+    script: bld.sh # [not win]
+  - name: cusolver
+    requirements:
+      build:
+        - python >=3
+        - requests
+        - 7za # [win]
+        - conda
+        - pyyaml
+      run:
+        - cublas 7.5.*
+        - cusparse 7.5.*
+    source:
+      path: ../scripts/
+    script: bld.bat # [win]
+    script: bld.sh # [not win]
+  - name: nvblas
+    requirements:
+      build:
+        - python >=3
+        - requests
+        - 7za # [win]
+        - conda
+        - pyyaml
+      run:
+        - cublas 7.5.*
+    source:
+      path: ../scripts/
+    script: bld.bat # [win]
+    script: bld.sh # [not win]
+  - name: nvrtc
+    requirements:
+      build:
+        - python >=3
+        - requests
+        - 7za # [win]
+        - conda
+        - pyyaml
+      run:
+        - cudart 7.5.*
+    source:
+      path: ../scripts/
+    script: bld.bat # [win]
+    script: bld.sh # [not win]
+  - name: nvvm
+    requirements:
+      build:
+        - python >=3
+        - requests
+        - 7za # [win]
+        - conda
+        - pyyaml
+      run:
+        - cudart 7.5.*
+    source:
+      path: ../scripts/
+    script: bld.bat # [win]
+    script: bld.sh # [not win]
+  - name: cupti
+    requirements:
+      build:
+        - python >=3
+        - requests
+        - 7za # [win]
+        - conda
+        - pyyaml
+      run:
+        - cudart 7.5.*
+    source:
+      path: ../scripts/
+    script: bld.bat # [win]
+    script: bld.sh # [not win]
+
 
 source:
-    path: ../scripts/
+  path: ../scripts/
 
 test:
   requires:

--- a/condarecipe7.5/meta.yaml
+++ b/condarecipe7.5/meta.yaml
@@ -15,17 +15,17 @@ requirements:
     - conda
     - pyyaml
   run:
-    - cudart 7.5.*
-    - cublas 7.5.*
-    - cufft 7.5.*
-    - curand 7.5.*
-    - cusparse 7.5.*
-    - cusolver 7.5.*
-    - npp 7.5.*
-    - nvblas 7.5.*
-    - nvrtc 7.5.*
-    - nvvm 7.5.*
-    - cupti 7.5.*
+    - {{ pin_subpackage('cudart') }}
+    - {{ pin_subpackage('cublas') }}
+    - {{ pin_subpackage('cufft') }}
+    - {{ pin_subpackage('curand') }}
+    - {{ pin_subpackage('cusparse') }}
+    - {{ pin_subpackage('cusolver') }}
+    - {{ pin_subpackage('npp') }}
+    - {{ pin_subpackage('nvblas') }}
+    - {{ pin_subpackage('nvrtc') }}
+    - {{ pin_subpackage('nvvm') }}
+    - {{ pin_subpackage('cupti') }}
 
 outputs:
   - name: cudart

--- a/condarecipe8.0/meta.yaml
+++ b/condarecipe8.0/meta.yaml
@@ -15,19 +15,19 @@ requirements:
     - conda
     - pyyaml
   run:
-    - cudart 8.0.*
-    - cublas 8.0.*
-    - cufft 8.0.*
-    - curand 8.0.*
-    - cusparse 8.0.*
-    - cusolver 8.0.*
-    - npp 8.0.*
-    - nvblas 8.0.*
-    - nvrtc 8.0.*
-    - nvvm 8.0.*
-    - nvtx 8.0.*
-    - nvgraph 8.0.*
-    - cupti 8.0.*
+    - {{ pin_subpackage('cudart') }}
+    - {{ pin_subpackage('cublas') }}
+    - {{ pin_subpackage('cufft') }}
+    - {{ pin_subpackage('curand') }}
+    - {{ pin_subpackage('cusparse') }}
+    - {{ pin_subpackage('cusolver') }}
+    - {{ pin_subpackage('npp') }}
+    - {{ pin_subpackage('nvblas') }}
+    - {{ pin_subpackage('nvrtc') }}
+    - {{ pin_subpackage('nvvm') }}
+    - {{ pin_subpackage('nvtx') }}
+    - {{ pin_subpackage('nvgraph') }}
+    - {{ pin_subpackage('cupti') }}
 
 outputs:
   - name: cudart

--- a/condarecipe8.0/meta.yaml
+++ b/condarecipe8.0/meta.yaml
@@ -1,9 +1,9 @@
 package:
-   name: cudatoolkit
-   version: 8.0
+  name: cudatoolkit
+  version: 8.0
 
 build:
-  number: 3
+  number: 4
   script_env:
     - NVTOOLSEXT_INSTALL_PATH
 
@@ -14,9 +14,207 @@ requirements:
     - 7za # [win]
     - conda
     - pyyaml
+  run:
+    - cudart 8.0.*
+    - cublas 8.0.*
+    - cufft 8.0.*
+    - curand 8.0.*
+    - cusparse 8.0.*
+    - cusolver 8.0.*
+    - npp 8.0.*
+    - nvblas 8.0.*
+    - nvrtc 8.0.*
+    - nvvm 8.0.*
+    - nvtx 8.0.*
+    - nvgraph 8.0.*
+    - cupti 8.0.*
+
+outputs:
+  - name: cudart
+    requirements:
+      build:
+        - python >=3
+        - requests
+        - 7za # [win]
+        - conda
+        - pyyaml
+    source:
+      path: ../scripts/
+    script: bld.bat # [win]
+    script: bld.sh # [not win]
+  - name: cublas
+    requirements:
+      build:
+        - python >=3
+        - requests
+        - 7za # [win]
+        - conda
+        - pyyaml
+      run:
+        - cudart 8.0.*
+    source:
+      path: ../scripts/
+    script: bld.bat # [win]
+    script: bld.sh # [not win]
+  - name: cufft
+    requirements:
+      build:
+        - python >=3
+        - requests
+        - 7za # [win]
+        - conda
+        - pyyaml
+      run:
+        - cudart 8.0.*
+    source:
+      path: ../scripts/
+    script: bld.bat # [win]
+    script: bld.sh # [not win]
+  - name: curand
+    requirements:
+      build:
+        - python >=3
+        - requests
+        - 7za # [win]
+        - conda
+        - pyyaml
+      run:
+        - cudart 8.0.*
+    source:
+      path: ../scripts/
+    script: bld.bat # [win]
+    script: bld.sh # [not win]
+  - name: cusparse
+    requirements:
+      build:
+        - python >=3
+        - requests
+        - 7za # [win]
+        - conda
+        - pyyaml
+      run:
+        - cudart 8.0.*
+    source:
+      path: ../scripts/
+    script: bld.bat # [win]
+    script: bld.sh # [not win]
+  - name: npp
+    requirements:
+      build:
+        - python >=3
+        - requests
+        - 7za # [win]
+        - conda
+        - pyyaml
+      run:
+        - cudart 8.0.*
+    source:
+      path: ../scripts/
+    script: bld.bat # [win]
+    script: bld.sh # [not win]
+  - name: cusolver
+    requirements:
+      build:
+        - python >=3
+        - requests
+        - 7za # [win]
+        - conda
+        - pyyaml
+      run:
+        - cublas 8.0.*
+        - cusparse 8.0.*
+    source:
+      path: ../scripts/
+    script: bld.bat # [win]
+    script: bld.sh # [not win]
+  - name: nvblas
+    requirements:
+      build:
+        - python >=3
+        - requests
+        - 7za # [win]
+        - conda
+        - pyyaml
+      run:
+        - cublas 8.0.*
+    source:
+      path: ../scripts/
+    script: bld.bat # [win]
+    script: bld.sh # [not win]
+  - name: nvrtc
+    requirements:
+      build:
+        - python >=3
+        - requests
+        - 7za # [win]
+        - conda
+        - pyyaml
+      run:
+        - cudart 8.0.*
+    source:
+      path: ../scripts/
+    script: bld.bat # [win]
+    script: bld.sh # [not win]
+  - name: nvvm
+    requirements:
+      build:
+        - python >=3
+        - requests
+        - 7za # [win]
+        - conda
+        - pyyaml
+      run:
+        - cudart 8.0.*
+    source:
+      path: ../scripts/
+    script: bld.bat # [win]
+    script: bld.sh # [not win]
+  - name: nvtx
+    requirements:
+      build:
+        - python >=3
+        - requests
+        - 7za # [win]
+        - conda
+        - pyyaml
+      run:
+        - cudart 8.0.*
+    source:
+      path: ../scripts/
+    script: bld.bat # [win]
+    script: bld.sh # [not win]
+  - name: cupti
+    requirements:
+      build:
+        - python >=3
+        - requests
+        - 7za # [win]
+        - conda
+        - pyyaml
+      run:
+        - cudart 8.0.*
+    source:
+      path: ../scripts/
+    script: bld.bat # [win]
+    script: bld.sh # [not win]
+  - name: nvgraph
+    requirements:
+      build:
+        - python >=3
+        - requests
+        - 7za # [win]
+        - conda
+        - pyyaml
+      run:
+        - cudart 8.0.*
+    source:
+      path: ../scripts/
+    script: bld.bat # [win]
+    script: bld.sh # [not win]
+
 
 source:
-    path: ../scripts/
+  path: ../scripts/
 
 test:
   requires:

--- a/condarecipe9.0/bld.bat
+++ b/condarecipe9.0/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" build.py
+if errorlevel 1 exit 1

--- a/condarecipe9.0/build.sh
+++ b/condarecipe9.0/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+python build.py

--- a/condarecipe9.0/meta.yaml
+++ b/condarecipe9.0/meta.yaml
@@ -1,9 +1,8 @@
 package:
   name: cudatoolkit
-  version: "8.0"
+  version: "9.0.176"
 
 build:
-  number: 4
   script_env:
     - NVTOOLSEXT_INSTALL_PATH
 
@@ -51,7 +50,7 @@ outputs:
         - conda
         - pyyaml
       run:
-        - cudart 8.0.*
+        - cudart 9.0.*
     source:
       path: ../scripts/
     script: bld.bat # [win]
@@ -65,7 +64,7 @@ outputs:
         - conda
         - pyyaml
       run:
-        - cudart 8.0.*
+        - cudart 9.0.*
     source:
       path: ../scripts/
     script: bld.bat # [win]
@@ -79,7 +78,7 @@ outputs:
         - conda
         - pyyaml
       run:
-        - cudart 8.0.*
+        - cudart 9.0.*
     source:
       path: ../scripts/
     script: bld.bat # [win]
@@ -93,7 +92,7 @@ outputs:
         - conda
         - pyyaml
       run:
-        - cudart 8.0.*
+        - cudart 9.0.*
     source:
       path: ../scripts/
     script: bld.bat # [win]
@@ -107,7 +106,7 @@ outputs:
         - conda
         - pyyaml
       run:
-        - cudart 8.0.*
+        - cudart 9.0.*
     source:
       path: ../scripts/
     script: bld.bat # [win]
@@ -121,8 +120,8 @@ outputs:
         - conda
         - pyyaml
       run:
-        - cublas 8.0.*
-        - cusparse 8.0.*
+        - cublas 9.0.*
+        - cusparse 9.0.*
     source:
       path: ../scripts/
     script: bld.bat # [win]
@@ -136,7 +135,7 @@ outputs:
         - conda
         - pyyaml
       run:
-        - cublas 8.0.*
+        - cublas 9.0.*
     source:
       path: ../scripts/
     script: bld.bat # [win]
@@ -150,7 +149,7 @@ outputs:
         - conda
         - pyyaml
       run:
-        - cudart 8.0.*
+        - cudart 9.0.*
     source:
       path: ../scripts/
     script: bld.bat # [win]
@@ -164,7 +163,7 @@ outputs:
         - conda
         - pyyaml
       run:
-        - cudart 8.0.*
+        - cudart 9.0.*
     source:
       path: ../scripts/
     script: bld.bat # [win]
@@ -178,7 +177,7 @@ outputs:
         - conda
         - pyyaml
       run:
-        - cudart 8.0.*
+        - cudart 9.0.*
     source:
       path: ../scripts/
     script: bld.bat # [win]
@@ -192,7 +191,7 @@ outputs:
         - conda
         - pyyaml
       run:
-        - cudart 8.0.*
+        - cudart 9.0.*
     source:
       path: ../scripts/
     script: bld.bat # [win]
@@ -206,7 +205,7 @@ outputs:
         - conda
         - pyyaml
       run:
-        - cudart 8.0.*
+        - cudart 9.0.*
     source:
       path: ../scripts/
     script: bld.bat # [win]
@@ -216,6 +215,3 @@ outputs:
 source:
   path: ../scripts/
 
-test:
-  requires:
-    - numba

--- a/condarecipe9.1/bld.bat
+++ b/condarecipe9.1/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" build.py
+if errorlevel 1 exit 1

--- a/condarecipe9.1/build.sh
+++ b/condarecipe9.1/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+python build.py

--- a/condarecipe9.1/meta.yaml
+++ b/condarecipe9.1/meta.yaml
@@ -1,10 +1,11 @@
 package:
   name: cudatoolkit
-  version: "9.1.85"
+  version: "9.1"
 
 build:
   script_env:
     - NVTOOLSEXT_INSTALL_PATH
+  number: 1
 
 requirements:
   build:

--- a/condarecipe9.1/meta.yaml
+++ b/condarecipe9.1/meta.yaml
@@ -1,0 +1,217 @@
+package:
+  name: cudatoolkit
+  version: "9.1.85"
+
+build:
+  script_env:
+    - NVTOOLSEXT_INSTALL_PATH
+
+requirements:
+  build:
+    - python >=3
+    - requests
+    - 7za # [win]
+    - conda
+    - pyyaml
+  run:
+    - {{ pin_subpackage('cudart') }}
+    - {{ pin_subpackage('cublas') }}
+    - {{ pin_subpackage('cufft') }}
+    - {{ pin_subpackage('curand') }}
+    - {{ pin_subpackage('cusparse') }}
+    - {{ pin_subpackage('cusolver') }}
+    - {{ pin_subpackage('npp') }}
+    - {{ pin_subpackage('nvblas') }}
+    - {{ pin_subpackage('nvrtc') }}
+    - {{ pin_subpackage('nvvm') }}
+    - {{ pin_subpackage('nvtx') }}
+    - {{ pin_subpackage('nvgraph') }}
+    - {{ pin_subpackage('cupti') }}
+
+outputs:
+  - name: cudart
+    requirements:
+      build:
+        - python >=3
+        - requests
+        - 7za # [win]
+        - conda
+        - pyyaml
+    source:
+      path: ../scripts/
+    script: bld.bat # [win]
+    script: bld.sh # [not win]
+  - name: cublas
+    requirements:
+      build:
+        - python >=3
+        - requests
+        - 7za # [win]
+        - conda
+        - pyyaml
+      run:
+        - cudart 9.1.*
+    source:
+      path: ../scripts/
+    script: bld.bat # [win]
+    script: bld.sh # [not win]
+  - name: cufft
+    requirements:
+      build:
+        - python >=3
+        - requests
+        - 7za # [win]
+        - conda
+        - pyyaml
+      run:
+        - cudart 9.1.*
+    source:
+      path: ../scripts/
+    script: bld.bat # [win]
+    script: bld.sh # [not win]
+  - name: curand
+    requirements:
+      build:
+        - python >=3
+        - requests
+        - 7za # [win]
+        - conda
+        - pyyaml
+      run:
+        - cudart 9.1.*
+    source:
+      path: ../scripts/
+    script: bld.bat # [win]
+    script: bld.sh # [not win]
+  - name: cusparse
+    requirements:
+      build:
+        - python >=3
+        - requests
+        - 7za # [win]
+        - conda
+        - pyyaml
+      run:
+        - cudart 9.1.*
+    source:
+      path: ../scripts/
+    script: bld.bat # [win]
+    script: bld.sh # [not win]
+  - name: npp
+    requirements:
+      build:
+        - python >=3
+        - requests
+        - 7za # [win]
+        - conda
+        - pyyaml
+      run:
+        - cudart 9.1.*
+    source:
+      path: ../scripts/
+    script: bld.bat # [win]
+    script: bld.sh # [not win]
+  - name: cusolver
+    requirements:
+      build:
+        - python >=3
+        - requests
+        - 7za # [win]
+        - conda
+        - pyyaml
+      run:
+        - cublas 9.1.*
+        - cusparse 9.1.*
+    source:
+      path: ../scripts/
+    script: bld.bat # [win]
+    script: bld.sh # [not win]
+  - name: nvblas
+    requirements:
+      build:
+        - python >=3
+        - requests
+        - 7za # [win]
+        - conda
+        - pyyaml
+      run:
+        - cublas 9.1.*
+    source:
+      path: ../scripts/
+    script: bld.bat # [win]
+    script: bld.sh # [not win]
+  - name: nvrtc
+    requirements:
+      build:
+        - python >=3
+        - requests
+        - 7za # [win]
+        - conda
+        - pyyaml
+      run:
+        - cudart 9.1.*
+    source:
+      path: ../scripts/
+    script: bld.bat # [win]
+    script: bld.sh # [not win]
+  - name: nvvm
+    requirements:
+      build:
+        - python >=3
+        - requests
+        - 7za # [win]
+        - conda
+        - pyyaml
+      run:
+        - cudart 9.1.*
+    source:
+      path: ../scripts/
+    script: bld.bat # [win]
+    script: bld.sh # [not win]
+  - name: nvtx
+    requirements:
+      build:
+        - python >=3
+        - requests
+        - 7za # [win]
+        - conda
+        - pyyaml
+      run:
+        - cudart 9.1.*
+    source:
+      path: ../scripts/
+    script: bld.bat # [win]
+    script: bld.sh # [not win]
+  - name: cupti
+    requirements:
+      build:
+        - python >=3
+        - requests
+        - 7za # [win]
+        - conda
+        - pyyaml
+      run:
+        - cudart 9.1.*
+    source:
+      path: ../scripts/
+    script: bld.bat # [win]
+    script: bld.sh # [not win]
+  - name: nvgraph
+    requirements:
+      build:
+        - python >=3
+        - requests
+        - 7za # [win]
+        - conda
+        - pyyaml
+      run:
+        - cudart 9.1.*
+    source:
+      path: ../scripts/
+    script: bld.bat # [win]
+    script: bld.sh # [not win]
+
+
+source:
+  path: ../scripts/
+

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -16,7 +16,7 @@ from conda.exports import download, hashsum_file
 import pickle
 
 config = {}
-versions = ['7.5', '8.0', '9.0']
+versions = ['7.5', '8.0', '9.0', '9.1.85']
 for v in versions:
     config[v] = {'linux': {}, 'windows': {}, 'osx': {}}
 
@@ -150,9 +150,9 @@ cu_8['osx'] = {'blob': 'cuda_8.0.61_mac-dmg',
                'libdevice_lib_fmt': 'libdevice.compute_{0}.bc'
                }
 
-
-# CUDA 9.0 setup
-# TODO Verify
+######################
+### CUDA 9.0 setup ###
+######################
 cu_9 = config['9.0']
 cu_9['base_url'] = "https://developer.nvidia.com/compute/cuda/9.0/Prod/"
 cu_9['installers_url_ext'] = 'local_installers/'
@@ -184,7 +184,7 @@ cu_9['linux'] = {'blob': 'cuda_9.0.176_384.81_linux-run',
                  'libdevice_lib_fmt': 'libdevice.{0}.bc'
                  }
 
-cu_9['windows'] = {'blob': 'cuda_9.0.176_win10-exe',
+cu_9['windows'] = {'blob': 'cuda_9.0.176_windows-exe',
                    'patches': [],
                    'cuda_lib_fmt': '{0}64_90.dll',
                    'nvtoolsext_fmt': '{0}64_1.dll',
@@ -199,7 +199,60 @@ cu_9['osx'] = {'blob': 'cuda_9.0.176_mac-dmg',
                'patches': [],
                'cuda_lib_fmt': 'lib{0}.9.0.dylib',
                'nvtoolsext_fmt': 'lib{0}.1.dylib',
-               'nvvm_lib_fmt': 'lib{0}.3.1.0.dylib',
+               'nvvm_lib_fmt': 'lib{0}.3.2.0.dylib',
+               'libdevice_lib_fmt': 'libdevice.{0}.bc'
+               }
+
+######################
+### CUDA 9.1 setup ###
+######################
+cu_91 = config['9.1.85']
+cu_91['base_url'] = "https://developer.nvidia.com/compute/cuda/9.1/Prod/"
+cu_91['installers_url_ext'] = 'local_installers/'
+cu_91['md5_url'] = "https://developer.download.nvidia.com/compute/cuda/9.1/Prod/docs/sidebar/md5sum.txt"
+cu_91['patch_url_ext'] = ''
+cu_91['pkg_libs'] = {
+    'cudart': ['cudart'],
+    'cufft': ['cufft'],
+    'cublas': ['cublas'],
+    'cusparse': ['cusparse'],
+    'curand': ['curand'],
+    'cusolver': ['cusolver'],
+    'npp': ['nppc', 'nppial', 'nppicc', 'nppicom', 'nppidei', 'nppif', 'nppig', 'nppim', 'nppist', 'nppisu', 'nppitc', 'npps'],
+    'nvrtc': ['nvrtc', 'nvrtc-builtins'],
+    'nvblas': ['nvblas'],
+    'nvgraph': ['nvgraph'],
+    'cupti': ['cupti'],
+    'nvtx': ['nvToolsExt'], # Change package name to nvToolsExt?
+    'nvvm': ['nvvm', '10'],
+    }
+cu_91['libdevice_versions'] = ['10']
+
+cu_91['linux'] = {'blob': 'cuda_9.1.85_387.26_linux',
+                 'patches': [],
+                 # need globs to handle symlinks
+                 'cuda_lib_fmt': 'lib{0}.so*',
+                 'nvtoolsext_fmt': 'lib{0}.so*',
+                 'nvvm_lib_fmt': 'lib{0}.so*',
+                 'libdevice_lib_fmt': 'libdevice.{0}.bc'
+                 }
+
+cu_91['windows'] = {'blob': 'cuda_9.1.85_windows',
+                   'patches': [],
+                   'cuda_lib_fmt': '{0}64_91.dll',
+                   'nvtoolsext_fmt': '{0}64_1.dll',
+                   'nvvm_lib_fmt': '{0}64_32_0.dll',
+                   'libdevice_lib_fmt': 'libdevice.{0}.bc',
+                   'NvToolsExtPath' :
+                       os.path.join('c:' + os.sep, 'Program Files',
+                                    'NVIDIA Corporation', 'NVToolsExt', 'bin')
+                   }
+
+cu_91['osx'] = {'blob': 'cuda_9.1.85_mac',
+               'patches': [],
+               'cuda_lib_fmt': 'lib{0}.9.1.dylib',
+               'nvtoolsext_fmt': 'lib{0}.1.dylib',
+               'nvvm_lib_fmt': 'lib{0}.3.2.0.dylib',
                'libdevice_lib_fmt': 'libdevice.{0}.bc'
                }
 
@@ -504,7 +557,8 @@ class LinuxExtractor(Extractor):
         patches = self.patches
         os.chmod(runfile, 0o777)
         check_call([os.path.join(self.src_dir, runfile),
-                    '--toolkitpath', extract_dir, '--toolkit', '--silent'])
+                    '--toolkitpath', extract_dir, '--toolkit', '--silent',
+                    '--no-drm'])
         for p in patches:
             os.chmod(p, 0o777)
             check_call([os.path.join(self.src_dir, p),

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -16,7 +16,7 @@ from conda.exports import download, hashsum_file
 import pickle
 
 config = {}
-versions = ['7.5', '8.0', '9.0', '9.1.85']
+versions = ['7.5', '8.0', '9.0', '9.1']
 for v in versions:
     config[v] = {'linux': {}, 'windows': {}, 'osx': {}}
 
@@ -206,11 +206,11 @@ cu_9['osx'] = {'blob': 'cuda_9.0.176_mac-dmg',
 ######################
 ### CUDA 9.1 setup ###
 ######################
-cu_91 = config['9.1.85']
+cu_91 = config['9.1']
 cu_91['base_url'] = "https://developer.nvidia.com/compute/cuda/9.1/Prod/"
 cu_91['installers_url_ext'] = 'local_installers/'
 cu_91['md5_url'] = "https://developer.download.nvidia.com/compute/cuda/9.1/Prod/docs/sidebar/md5sum.txt"
-cu_91['patch_url_ext'] = ''
+cu_91['patch_url_ext'] = 'patches/1/'
 cu_91['pkg_libs'] = {
     'cudart': ['cudart'],
     'cufft': ['cufft'],
@@ -229,7 +229,7 @@ cu_91['pkg_libs'] = {
 cu_91['libdevice_versions'] = ['10']
 
 cu_91['linux'] = {'blob': 'cuda_9.1.85_387.26_linux',
-                 'patches': [],
+                 'patches': ['cuda_9.1.85.1_linux'],
                  # need globs to handle symlinks
                  'cuda_lib_fmt': 'lib{0}.so*',
                  'nvtoolsext_fmt': 'lib{0}.so*',
@@ -238,7 +238,7 @@ cu_91['linux'] = {'blob': 'cuda_9.1.85_387.26_linux',
                  }
 
 cu_91['windows'] = {'blob': 'cuda_9.1.85_windows',
-                   'patches': [],
+                   'patches': ['cuda_9.1.85.1_windows'],
                    'cuda_lib_fmt': '{0}64_91.dll',
                    'nvtoolsext_fmt': '{0}64_1.dll',
                    'nvvm_lib_fmt': '{0}64_32_0.dll',
@@ -248,7 +248,7 @@ cu_91['windows'] = {'blob': 'cuda_9.1.85_windows',
                                     'NVIDIA Corporation', 'NVToolsExt', 'bin')
                    }
 
-cu_91['osx'] = {'blob': 'cuda_9.1.85_mac',
+cu_91['osx'] = {'blob': 'cuda_9.1.128_mac',
                'patches': [],
                'cuda_lib_fmt': 'lib{0}.9.1.dylib',
                'nvtoolsext_fmt': 'lib{0}.1.dylib',

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -13,6 +13,7 @@ from subprocess import check_call
 from tempfile import TemporaryDirectory as tempdir
 
 from conda.exports import download, hashsum_file
+import pickle
 
 config = {}
 versions = ['7.5', '8.0', '9.0']
@@ -59,19 +60,19 @@ cu_75['base_url'] = "http://developer.download.nvidia.com/compute/cuda/7.5/Prod/
 cu_75['patch_url_ext'] = ''
 cu_75['installers_url_ext'] = 'local_installers/'
 cu_75['md5_url'] = "http://developer.download.nvidia.com/compute/cuda/7.5/Prod/docs/sidebar/md5sum.txt"
-cu_75['cuda_libraries'] = [
-    'cublas',
-    'cudart',
-    'cufft',
-    'curand',
-    'cusparse',
-    'cusolver',
-    'nppc',
-    'nppi',
-    'npps',
-    'nvrtc-builtins',
-    'nvrtc',
-]
+cu_75['pkg_libs'] = {
+    'cudart': ['cudart'],
+    'cufft': ['cufft'],
+    'cublas': ['cublas'],
+    'cusparse': ['cusparse'],
+    'cusolver': ['cusolver'],
+    'curand': ['curand'],
+    'npp': ['nppc', 'nppi', 'npps'],
+    'nvblas': ['nvblas'],
+    'nvrtc': ['nvrtc', 'nvrtc-builtins'],
+    'nvvm': ['nvvm', '20.10', '30.10', '35.10', '50.10'],
+    'cupti': ['cupti']
+    }
 cu_75['libdevice_versions'] = ['20.10', '30.10', '35.10', '50.10']
 
 cu_75['linux'] = {'blob': 'cuda_7.5.18_linux.run',
@@ -104,20 +105,21 @@ cu_8['base_url'] = "https://developer.nvidia.com/compute/cuda/8.0/Prod2/"
 cu_8['installers_url_ext'] = 'local_installers/'
 cu_8['patch_url_ext'] = 'patches/2/'
 cu_8['md5_url'] = "https://developer.nvidia.com/compute/cuda/8.0/Prod2/docs/sidebar/md5sum-txt"
-cu_8['cuda_libraries'] = [
-    'cudart',
-    'cufft',
-    'cublas',
-    'cusparse',
-    'cusolver',
-    'curand',
-    'nppc',
-    'nppi',
-    'npps',
-    'nvrtc',
-    'nvrtc-builtins',
-    'nvToolsExt',
-]
+cu_8['pkg_libs'] = {
+    'cudart': ['cudart'],
+    'cufft': ['cufft'],
+    'cublas': ['cublas'],
+    'cusparse': ['cusparse'],
+    'curand': ['curand'],
+    'cusolver': ['cusolver'],
+    'npp': ['nppc', 'nppi', 'npps'],
+    'nvrtc': ['nvrtc', 'nvrtc-builtins'],
+    'nvblas': ['nvblas'],
+    'nvgraph': ['nvgraph'],
+    'cupti': ['cupti'],
+    'nvtx': ['nvToolsExt'], # Change package name to nvToolsExt?
+    'nvvm': ['nvvm', '20.10', '30.10', '35.10', '50.10'],
+    }
 cu_8['libdevice_versions'] = ['20.10', '30.10', '35.10', '50.10']
 
 cu_8['linux'] = {'blob': 'cuda_8.0.61_375.26_linux-run',
@@ -160,7 +162,7 @@ class Extractor(object):
 
     libdir = {'linux': 'lib',
               'osx': 'lib',
-              'windows': 'DLLs'}
+              'windows': os.path.join('Library', 'bin')}
 
     def __init__(self, version, ver_config, plt_config):
         """Initialise an instance:
@@ -174,8 +176,8 @@ class Extractor(object):
         self.base_url = ver_config['base_url']
         self.patch_url_ext = ver_config['patch_url_ext']
         self.installers_url_ext = ver_config['installers_url_ext']
-        self.cuda_libraries = ver_config['cuda_libraries']
         self.libdevice_versions = ver_config['libdevice_versions']
+        self.pkg_dict = ver_config['pkg_libs']
         self.cu_blob = plt_config['blob']
         self.cuda_lib_fmt = plt_config['cuda_lib_fmt']
         self.nvtoolsext_fmt = plt_config.get('nvtoolsext_fmt')
@@ -193,20 +195,29 @@ class Extractor(object):
         except FileExistsError:
             pass
 
+    def create_link_scripts(self, pkg_name):
+        pass
+
     def download_blobs(self):
         """Downloads the binary blobs to the $SRC_DIR
         """
         dl_url = urlparse.urljoin(self.base_url, self.installers_url_ext)
         dl_url = urlparse.urljoin(dl_url, self.cu_blob)
         dl_path = os.path.join(self.src_dir, self.cu_blob)
-        print("downloading %s to %s" % (dl_url, dl_path))
-        download(dl_url, dl_path)
+        if not os.path.isfile(dl_path):
+            print("downloading %s to %s" % (dl_url, dl_path))
+            download(dl_url, dl_path)
+        else:
+            print("Using existing downloaded file: %s" % dl_path)
         for p in self.patches:
             dl_url = urlparse.urljoin(self.base_url, self.patch_url_ext)
             dl_url = urlparse.urljoin(dl_url, p)
             dl_path = os.path.join(self.src_dir, p)
-            print("downloading %s to %s" % (dl_url, dl_path))
-            download(dl_url, dl_path)
+            if not os.path.isfile(dl_path):
+                print("downloading %s to %s" % (dl_url, dl_path))
+                download(dl_url, dl_path)
+            else:
+                print("Using existing downloaded patch: %s" % dl_path)
 
     def check_md5(self):
         """Checks the md5sums of the downloaded binaries
@@ -239,7 +250,7 @@ class Extractor(object):
         """
         raise RuntimeError('Must implement')
 
-    def get_paths(self, libraries, dirpath, template):
+    def get_paths(self, libraries, dirpath, template, pkg_filter=None):
         """Gets the paths to the various cuda libraries and bc files
         """
         pathlist = []
@@ -275,21 +286,12 @@ class Extractor(object):
             pathlist.extend(pathsforlib)
         return pathlist
 
-    def copy_files(self, cuda_lib_dir, nvvm_lib_dir, libdevice_lib_dir):
+    def copy_files(self, pkg_name, cuda_lib_dir, nvvm_lib_dir, libdevice_lib_dir):
         """Copies the various cuda libraries and bc files to the output_dir
         """
-        filepaths = []
-        # nvToolsExt is different to the rest of the cuda libraries,
-        # it follows a different naming convention, this accommodates...
-        cudalibs = [x for x in self.cuda_libraries if x != 'nvToolsExt']
-        filepaths += self.get_paths(cudalibs, cuda_lib_dir, self.cuda_lib_fmt)
-        if 'nvToolsExt' in self.cuda_libraries:
-            filepaths += self.get_paths(['nvToolsExt'], cuda_lib_dir,
-                                        self.nvtoolsext_fmt)
-        filepaths += self.get_paths(['nvvm'], nvvm_lib_dir, self.nvvm_lib_fmt)
-        filepaths += self.get_paths(self.libdevice_versions, libdevice_lib_dir,
-                                    self.libdevice_lib_fmt)
-
+        if pkg_name == 'cudatoolkit':
+            return
+        filepaths = self._get_filepaths(pkg_name, cuda_lib_dir, nvvm_lib_dir, libdevice_lib_dir)
         for fn in filepaths:
             if os.path.islink(fn):
                 # replicate symlinks
@@ -302,10 +304,26 @@ class Extractor(object):
                 print('copying %s to %s' % (fn, self.output_dir))
                 shutil.copy(fn, self.output_dir)
 
-    def dump_config(self):
+    def _get_filepaths(self, pkg_name, cuda_lib_dir, nvvm_lib_dir, libdevice_lib_dir):
+        filepaths = []
+        # nvToolsExt (nvtx) and nvvm are different from the rest of the cuda libraries,
+        # it follows a different naming convention, this accommodates...
+        if pkg_name == 'nvtx':
+            filepaths += self.get_paths(self.pkg_dict[pkg_name], cuda_lib_dir,
+                                        self.nvtoolsext_fmt)
+        elif pkg_name == 'nvvm':
+            filepaths += self.get_paths(('nvvm',), nvvm_lib_dir, self.nvvm_lib_fmt)
+            filepaths += self.get_paths(self.libdevice_versions, libdevice_lib_dir,
+                                        self.libdevice_lib_fmt)
+        else:
+            filepaths += self.get_paths(self.pkg_dict[pkg_name], cuda_lib_dir,
+                                        self.cuda_lib_fmt)
+        return filepaths
+
+    def dump_config(self, pkg_name):
         """Dumps the config dictionary into the output directory
         """
-        dumpfile = os.path.join(self.output_dir, 'cudatoolkit_config.yaml')
+        dumpfile = os.path.join(self.output_dir, '{}_config.yaml'.format(pkg_name))
         with open(dumpfile, 'w') as f:
             yaml.dump(self.config, f, default_flow_style=False)
 
@@ -314,63 +332,105 @@ class WindowsExtractor(Extractor):
     """The windows extractor
     """
 
-    def copy(self, *args):
-        store, = args
-        self.copy_files(
-            cuda_lib_dir=store,
-            nvvm_lib_dir=store,
-            libdevice_lib_dir=store)
+    def copy(self, pkg_name):
+        self.copy_files(pkg_name,
+            cuda_lib_dir=self.store,
+            nvvm_lib_dir=self.store,
+            libdevice_lib_dir=self.store)
 
-    def extract(self):
+    def make_link_scripts(self, pkg_name):
+        if pkg_name == 'cudatoolkit':
+            self._create_cudatoolkit_link_scripts()
+
+
+    def _create_cudatoolkit_link_scripts(self):
+        # Can this be pulled from meta.yaml?
+        cudatoolkit_numba_deps = ['cudart', 'cufft', 'cublas',
+                                  'cusparse', 'curand', 'cusolver',
+                                  'npp', 'nvrtc', 'nvvm']
+        post_link_lines = []
+        pre_unlink_lines = []
+        post_link_template = ("mklink /H %PREFIX%\\DLLs\\{0} "
+                              "%PREFIX%\Library\\bin\\{0} "
+                              ">> %PREFIX%\\.messages.txt")
+        pre_unlink_template = ("del %PREFIX%\\DLLs\\{0} "
+                               ">> %PREFIX%\\.messages.txt")
+        for dep in cudatoolkit_numba_deps:
+            filepaths = self._get_filepaths(dep, self.store,
+                                            self.store, self.store)
+            fns = [os.path.basename(filepath) for filepath in filepaths]
+            post_link_lines += (post_link_template.format(fn) for fn in fns)
+            pre_unlink_lines += (pre_unlink_template.format(fn) for fn in fns)
+        print("Post-Link Commands:\n")
+        print("\n".join(post_link_lines))
+        print("Pre-Unlink Link Commands:\n")
+        print("\n".join(post_link_lines))
+        post_link_fn = os.path.join(self.prefix, "Scripts",
+                                    ".cudatoolkit-post-link.bat")
+        pre_unlink_fn = os.path.join(self.prefix, "Scripts",
+                                    ".cudatoolkit-pre-unlink.bat")
+        with open(post_link_fn, "w") as post_link_file:
+            for line in post_link_lines:
+                post_link_file.write("{}\n".format(line))
+        with open(pre_unlink_fn, "w") as pre_unlink_file:
+            for line in pre_unlink_lines:
+                pre_unlink_file.write("{}\n".format(line))
+
+
+    def extract(self, extract_dir):
         runfile = self.cu_blob
         patches = self.patches
         try:
-            with tempdir() as tmpd:
-                extract_name = '__extracted'
-                extractdir = os.path.join(tmpd, extract_name)
-                os.mkdir(extract_name)
-
+            extract_name = '__extracted'
+            extractdir = os.path.join(extract_dir, extract_name)
+            store_name = 'DLLs'
+            self.store = os.path.join(extract_dir, store_name)
+            try:
+                os.mkdir(extractdir)
                 check_call(['7za', 'x', '-o%s' %
                             extractdir, os.path.join(self.src_dir, runfile)])
                 for p in patches:
                     check_call(['7za', 'x', '-aoa', '-o%s' %
                                 extractdir, os.path.join(self.src_dir, p)])
-                    
-                nvt_path = os.environ.get('NVTOOLSEXT_INSTALL_PATH', self.nvtoolsextpath)
-                print("NvToolsExt path: %s" % nvt_path)
-                if nvt_path is not None:
-                    if not Path(nvt_path).is_dir():
-                        msg = ("NVTOOLSEXT_INSTALL_PATH is invalid "
-                                "or inaccessible.")
-                        raise ValueError(msg)
-                    
-                # fetch all the dlls into DLLs
-                store_name = 'DLLs'
-                store = os.path.join(tmpd, store_name)
-                os.mkdir(store)
+            except FileExistsError:
+                print("Files already extracted.")
+
+                
+            nvt_path = os.environ.get('NVTOOLSEXT_INSTALL_PATH', self.nvtoolsextpath)
+            print("NvToolsExt path: %s" % nvt_path)
+            if nvt_path is not None:
+                if not Path(nvt_path).is_dir():
+                    msg = ("NVTOOLSEXT_INSTALL_PATH is invalid "
+                            "or inaccessible.")
+                    raise ValueError(msg)
+                
+            # fetch all the dlls into DLLs
+            try:
+                os.mkdir(self.store)
                 for path, dirs, files in os.walk(extractdir):
                     if 'jre' not in path:  # don't get jre dlls
                         for filename in fnmatch.filter(files, "*.dll"):
                             if not Path(os.path.join(
-                                    store, filename)).is_file():
+                                    self.store, filename)).is_file():
                                 shutil.copy(
                                     os.path.join(path, filename),
-                                    store)
+                                    self.store)
                         for filename in fnmatch.filter(files, "*.bc"):
                             if not Path(os.path.join(
-                                    store, filename)).is_file():
+                                    self.store, filename)).is_file():
                                 shutil.copy(
                                     os.path.join(path, filename),
-                                    store)
+                                    self.store)
                 if nvt_path is not None:
                     for path, dirs, files in os.walk(nvt_path):
                         for filename in fnmatch.filter(files, "*.dll"):
                             if not Path(os.path.join(
-                                    store, filename)).is_file():
+                                    self.store, filename)).is_file():
                                 shutil.copy(
                                     os.path.join(path, filename),
-                                    store)
-                self.copy(store)
+                                    self.store)
+            except FileExistsError:
+                print("Files already copied into store.")
         except PermissionError:
             # TODO: fix this
             # cuda 8 has files that refuse to delete, figure out perm changes
@@ -382,26 +442,25 @@ class LinuxExtractor(Extractor):
     """The linux extractor
     """
 
-    def copy(self, *args):
-        basepath = args[0]
-        self.copy_files(
+    def copy(self, pkg_name):
+        basepath = self.store
+        self.copy_files(pkg_name,
             cuda_lib_dir=os.path.join(
                 basepath, 'lib64'), nvvm_lib_dir=os.path.join(
                 basepath, 'nvvm', 'lib64'), libdevice_lib_dir=os.path.join(
                 basepath, 'nvvm', 'libdevice'))
 
-    def extract(self):
+    def extract(self, extract_dir):
         runfile = self.cu_blob
         patches = self.patches
         os.chmod(runfile, 0o777)
-        with tempdir() as tmpd:
-            check_call([os.path.join(self.src_dir, runfile),
-                        '--toolkitpath', tmpd, '--toolkit', '--silent'])
-            for p in patches:
-                os.chmod(p, 0o777)
-                check_call([os.path.join(self.src_dir, p),
-                            '--installdir', tmpd, '--accept-eula', '--silent'])
-            self.copy(tmpd)
+        check_call([os.path.join(self.src_dir, runfile),
+                    '--toolkitpath', extract_dir, '--toolkit', '--silent'])
+        for p in patches:
+            os.chmod(p, 0o777)
+            check_call([os.path.join(self.src_dir, p),
+                        '--installdir', extract_dir, '--accept-eula', '--silent'])
+        self.store = extract_dir
 
 
 @contextmanager
@@ -418,11 +477,11 @@ class OsxExtractor(Extractor):
     """The osx extractor
     """
 
-    def copy(self, *args):
-        basepath, store = args
-        self.copy_files(cuda_lib_dir=store,
-                        nvvm_lib_dir=store,
-                        libdevice_lib_dir=store)
+    def copy(self, pkg_name):
+        self.copy_files(pkg_name,
+                        cuda_lib_dir=self.store,
+                        nvvm_lib_dir=self.store,
+                        libdevice_lib_dir=self.store)
 
     def _extract_matcher(self, tarmembers):
         """matcher helper for tarfile.extractall()
@@ -443,29 +502,30 @@ class OsxExtractor(Extractor):
                             tar.extractall(
                                 store, members=self._extract_matcher(tar))
 
-    def extract(self):
+    def extract(self, extract_dir):
         runfile = self.cu_blob
         patches = self.patches
-        with tempdir() as tmpd:
-            # fetch all the dylibs into lib64, but first get them out of the
-            # image and tar.gzs into tmpstore
-            extract_store_name = 'tmpstore'
-            extract_store = os.path.join(tmpd, extract_store_name)
-            os.mkdir(extract_store)
-            store_name = 'lib64'
-            store = os.path.join(tmpd, store_name)
-            os.mkdir(store)
-            self._mount_extract(runfile, extract_store)
-            for p in self.patches:
-                self._mount_extract(p, extract_store)
-            for path, dirs, files in os.walk(extract_store):
-                for filename in fnmatch.filter(files, "*.dylib"):
-                    if not Path(os.path.join(store, filename)).is_file():
-                        shutil.copy(os.path.join(path, filename), store)
-                for filename in fnmatch.filter(files, "*.bc"):
-                    if not Path(os.path.join(store, filename)).is_file():
-                        shutil.copy(os.path.join(path, filename), store)
-            self.copy(tmpd, store)
+        # fetch all the dylibs into lib64, but first get them out of the
+        # image and tar.gzs into tmpstore
+        extract_store_name = 'tmpstore'
+        extract_store = os.path.join(extract_dir, extract_store_name)
+        os.mkdir(extract_store)
+        store_name = 'lib64'
+        self.store = os.path.join(extract_dir, store_name)
+        try:
+            os.mkdir(self.store)
+        except FileExistsError:
+            pass
+        self._mount_extract(runfile, extract_store)
+        for p in self.patches:
+            self._mount_extract(p, extract_store)
+        for path, dirs, files in os.walk(extract_store):
+            for filename in fnmatch.filter(files, "*.dylib"):
+                if not Path(os.path.join(self.store, filename)).is_file():
+                    shutil.copy(os.path.join(path, filename), self.store)
+            for filename in fnmatch.filter(files, "*.bc"):
+                if not Path(os.path.join(self.store, filename)).is_file():
+                    shutil.copy(os.path.join(path, filename), self.store)
 
 
 def getplatform():
@@ -490,6 +550,8 @@ def _main():
     # package version decl must match cuda release version
     cu_version = os.environ['PKG_VERSION']
 
+    print("CUDA Version: {}".format(cu_version))
+
     # get an extractor
     plat = getplatform()
     extractor_impl = dispatcher[plat]
@@ -501,12 +563,22 @@ def _main():
 
     # check md5sum
     extractor.check_md5()
+    try:
+        os.mkdir("blob_files")
+    except FileExistsError:
+        pass
 
-    # extract
-    extractor.extract()
+    # extract (just extracts libraries from distributed blob)
+    extractor.extract("blob_files")
+
+    pkg_name = os.environ['PKG_NAME']
+
+    extractor.copy(pkg_name)
+
+    extractor.make_link_scripts(pkg_name)
 
     # dump config
-    extractor.dump_config()
+    # extractor.dump_config(pkg_name)
 
 if __name__ == "__main__":
     _main()

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -152,7 +152,56 @@ cu_8['osx'] = {'blob': 'cuda_8.0.61_mac-dmg',
 
 
 # CUDA 9.0 setup
-# TODO
+# TODO Verify
+cu_9 = config['9.0']
+cu_9['base_url'] = "https://developer.nvidia.com/compute/cuda/9.0/Prod/"
+cu_9['installers_url_ext'] = 'local_installers/'
+cu_9['md5_url'] = "https://developer.download.nvidia.com/compute/cuda/9.0/Prod/docs/sidebar/md5sum.txt"
+cu_9['patch_url_ext'] = ''
+cu_9['pkg_libs'] = {
+    'cudart': ['cudart'],
+    'cufft': ['cufft'],
+    'cublas': ['cublas'],
+    'cusparse': ['cusparse'],
+    'curand': ['curand'],
+    'cusolver': ['cusolver'],
+    'npp': ['nppc', 'nppial', 'nppicc', 'nppicom', 'nppidei', 'nppif', 'nppig', 'nppim', 'nppist', 'nppisu', 'nppitc', 'npps'],
+    'nvrtc': ['nvrtc', 'nvrtc-builtins'],
+    'nvblas': ['nvblas'],
+    'nvgraph': ['nvgraph'],
+    'cupti': ['cupti'],
+    'nvtx': ['nvToolsExt'], # Change package name to nvToolsExt?
+    'nvvm': ['nvvm', '10'],
+    }
+cu_9['libdevice_versions'] = ['10']
+
+cu_9['linux'] = {'blob': 'cuda_9.0.176_384.81_linux-run',
+                 'patches': [],
+                 # need globs to handle symlinks
+                 'cuda_lib_fmt': 'lib{0}.so*',
+                 'nvtoolsext_fmt': 'lib{0}.so*',
+                 'nvvm_lib_fmt': 'lib{0}.so*',
+                 'libdevice_lib_fmt': 'libdevice.{0}.bc'
+                 }
+
+cu_9['windows'] = {'blob': 'cuda_9.0.176_win10-exe',
+                   'patches': [],
+                   'cuda_lib_fmt': '{0}64_90.dll',
+                   'nvtoolsext_fmt': '{0}64_1.dll',
+                   'nvvm_lib_fmt': '{0}64_32_0.dll',
+                   'libdevice_lib_fmt': 'libdevice.{0}.bc',
+                   'NvToolsExtPath' :
+                       os.path.join('c:' + os.sep, 'Program Files',
+                                    'NVIDIA Corporation', 'NVToolsExt', 'bin')
+                   }
+
+cu_9['osx'] = {'blob': 'cuda_9.0.176_mac-dmg',
+               'patches': [],
+               'cuda_lib_fmt': 'lib{0}.9.0.dylib',
+               'nvtoolsext_fmt': 'lib{0}.1.dylib',
+               'nvvm_lib_fmt': 'lib{0}.3.1.0.dylib',
+               'libdevice_lib_fmt': 'libdevice.{0}.bc'
+               }
 
 
 class Extractor(object):


### PR DESCRIPTION
Package all redistributable CUDA libraries as separate packages.
Cudatoolkit is now a metapackage that depends on these subpackages
Installation location of DLLs is changed to Library\bin on Windows.
Cudatoolkit metapackage hardlinks to expected location for numba via post-link script.

This script has only been tested on Windows. In principle, it should work for Linux and OSX as well, but testing is required. I also packaged the remaining libraries that are currently not included in cudatoolkit.(nvblas, cupti, and nvgraph). The current script does not currently dump the config dictionary YAML into the output directory...this can be added back if it is required...it's currently a bit redundant since all the individual libraries will have the same YAML dump.