### PR TITLE
Place libraries in Library/bin folder on Windows

### DIFF
--- a/condarecipe8.0/bld.bat
+++ b/condarecipe8.0/bld.bat
@@ -1,2 +1,9 @@
 "%PYTHON%" build.py
 if errorlevel 1 exit 1
+
+:: copy nvvm and libdevice into the DLLs folder so numba can use them
+mkdir "%PREFIX%\DLLs"
+xcopy /s /y "%PREFIX%\Library\bin\nvvm*" "%PREFIX%\DLLs\"
+if errorlevel 1 exit 1
+xcopy /s /y "%PREFIX%\Library\bin\libdevice*" "%PREFIX%\DLLs\"
+if errorlevel 1 exit 1

--- a/condarecipe8.0/meta.yaml
+++ b/condarecipe8.0/meta.yaml
@@ -3,7 +3,7 @@ package:
    version: 8.0
 
 build:
-  number: 3
+  number: 4
   script_env:
     - NVTOOLSEXT_INSTALL_PATH
 

--- a/condarecipe8.0/run_test.py
+++ b/condarecipe8.0/run_test.py
@@ -5,6 +5,11 @@ from numba.cuda.cudadrv.nvvm import NVVM
 
 
 def run_test():
+    # on windows only nvvm is available to numba
+    if sys.platform.startswith('win'):
+        nvvm = NVVM()
+        print("NVVM version", nvvm.get_version())
+        return nvvm.get_version() is not None
     if not test():
         return False
     nvvm = NVVM()
@@ -12,9 +17,6 @@ def run_test():
     # check pkg version matches lib pulled in
     gotlib = get_cudalib('cublas')
     lookfor = os.environ['PKG_VERSION']
-    if sys.platform.startswith('win'):
-        # windows libs have no dot
-        lookfor = lookfor.replace('.', '')
     return lookfor in gotlib
 
 

--- a/condarecipe9.0/bld.bat
+++ b/condarecipe9.0/bld.bat
@@ -1,2 +1,9 @@
 "%PYTHON%" build.py
 if errorlevel 1 exit 1
+
+:: copy nvvm and libdevice into the DLLs folder so numba can use them
+mkdir "%PREFIX%\DLLs"
+xcopy /s /y "%PREFIX%\Library\bin\nvvm*" "%PREFIX%\DLLs\"
+if errorlevel 1 exit 1
+xcopy /s /y "%PREFIX%\Library\bin\libdevice*" "%PREFIX%\DLLs\"
+if errorlevel 1 exit 1

--- a/condarecipe9.0/meta.yaml
+++ b/condarecipe9.0/meta.yaml
@@ -3,7 +3,7 @@ package:
    version: 9.0
 
 build:
-  number: 0
+  number: 1
   script_env:
     - NVTOOLSEXT_INSTALL_PATH
 

--- a/condarecipe9.0/run_test.py
+++ b/condarecipe9.0/run_test.py
@@ -5,6 +5,11 @@ from numba.cuda.cudadrv.nvvm import NVVM
 
 
 def run_test():
+    # on windows only nvvm is available to numba
+    if sys.platform.startswith('win'):
+        nvvm = NVVM()
+        print("NVVM version", nvvm.get_version())
+        return nvvm.get_version() is not None
     if not test():
         return False
     nvvm = NVVM()
@@ -12,9 +17,6 @@ def run_test():
     # check pkg version matches lib pulled in
     gotlib = get_cudalib('cublas')
     lookfor = os.environ['PKG_VERSION']
-    if sys.platform.startswith('win'):
-        # windows libs have no dot
-        lookfor = lookfor.replace('.', '')
     return lookfor in gotlib
 
 

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -280,7 +280,7 @@ class Extractor(object):
 
     libdir = {'linux': 'lib',
               'osx': 'lib',
-              'windows': 'DLLs'}
+              'windows': 'Library/bin'}
 
     def __init__(self, version, ver_config, plt_config):
         """Initialise an instance:


### PR DESCRIPTION
Library/bin is on PATH by default, DLLs is not which causes issues.
nvvm and libdevice are included in DLLs for compatibility with numba.