### PR TITLE
CUDA 9.2

### DIFF
--- a/condarecipe10.0/bld.bat
+++ b/condarecipe10.0/bld.bat
@@ -1,2 +1,9 @@
 "%PYTHON%" build.py
 if errorlevel 1 exit 1
+
+:: copy nvvm and libdevice into the DLLs folder so numba can use them
+mkdir "%PREFIX%\DLLs"
+xcopy /s /y "%PREFIX%\Library\bin\nvvm*" "%PREFIX%\DLLs\"
+if errorlevel 1 exit 1
+xcopy /s /y "%PREFIX%\Library\bin\libdevice*" "%PREFIX%\DLLs\"
+if errorlevel 1 exit 1

--- a/condarecipe10.0/run_test.py
+++ b/condarecipe10.0/run_test.py
@@ -5,6 +5,11 @@ from numba.cuda.cudadrv.nvvm import NVVM
 
 
 def run_test():
+    # on windows only nvvm is available to numba
+    if sys.platform.startswith('win'):
+        nvvm = NVVM()
+        print("NVVM version", nvvm.get_version())
+        return nvvm.get_version() is not None
     if not test():
         return False
     nvvm = NVVM()

--- a/condarecipe8.0/bld.bat
+++ b/condarecipe8.0/bld.bat
@@ -1,2 +1,9 @@
 "%PYTHON%" build.py
 if errorlevel 1 exit 1
+
+:: copy nvvm and libdevice into the DLLs folder so numba can use them
+mkdir "%PREFIX%\DLLs"
+xcopy /s /y "%PREFIX%\Library\bin\nvvm*" "%PREFIX%\DLLs\"
+if errorlevel 1 exit 1
+xcopy /s /y "%PREFIX%\Library\bin\libdevice*" "%PREFIX%\DLLs\"
+if errorlevel 1 exit 1

--- a/condarecipe8.0/meta.yaml
+++ b/condarecipe8.0/meta.yaml
@@ -3,7 +3,7 @@ package:
    version: 8.0
 
 build:
-  number: 3
+  number: 4
   script_env:
     - NVTOOLSEXT_INSTALL_PATH
 

--- a/condarecipe8.0/run_test.py
+++ b/condarecipe8.0/run_test.py
@@ -5,6 +5,11 @@ from numba.cuda.cudadrv.nvvm import NVVM
 
 
 def run_test():
+    # on windows only nvvm is available to numba
+    if sys.platform.startswith('win'):
+        nvvm = NVVM()
+        print("NVVM version", nvvm.get_version())
+        return nvvm.get_version() is not None
     if not test():
         return False
     nvvm = NVVM()
@@ -12,9 +17,6 @@ def run_test():
     # check pkg version matches lib pulled in
     gotlib = get_cudalib('cublas')
     lookfor = os.environ['PKG_VERSION']
-    if sys.platform.startswith('win'):
-        # windows libs have no dot
-        lookfor = lookfor.replace('.', '')
     return lookfor in gotlib
 
 

--- a/condarecipe9.0/bld.bat
+++ b/condarecipe9.0/bld.bat
@@ -1,2 +1,9 @@
 "%PYTHON%" build.py
 if errorlevel 1 exit 1
+
+:: copy nvvm and libdevice into the DLLs folder so numba can use them
+mkdir "%PREFIX%\DLLs"
+xcopy /s /y "%PREFIX%\Library\bin\nvvm*" "%PREFIX%\DLLs\"
+if errorlevel 1 exit 1
+xcopy /s /y "%PREFIX%\Library\bin\libdevice*" "%PREFIX%\DLLs\"
+if errorlevel 1 exit 1

--- a/condarecipe9.0/meta.yaml
+++ b/condarecipe9.0/meta.yaml
@@ -3,7 +3,7 @@ package:
    version: 9.0
 
 build:
-  number: 0
+  number: 1
   script_env:
     - NVTOOLSEXT_INSTALL_PATH
 

--- a/condarecipe9.0/run_test.py
+++ b/condarecipe9.0/run_test.py
@@ -5,6 +5,11 @@ from numba.cuda.cudadrv.nvvm import NVVM
 
 
 def run_test():
+    # on windows only nvvm is available to numba
+    if sys.platform.startswith('win'):
+        nvvm = NVVM()
+        print("NVVM version", nvvm.get_version())
+        return nvvm.get_version() is not None
     if not test():
         return False
     nvvm = NVVM()
@@ -12,9 +17,6 @@ def run_test():
     # check pkg version matches lib pulled in
     gotlib = get_cudalib('cublas')
     lookfor = os.environ['PKG_VERSION']
-    if sys.platform.startswith('win'):
-        # windows libs have no dot
-        lookfor = lookfor.replace('.', '')
     return lookfor in gotlib
 
 

--- a/condarecipe9.2/bld.bat
+++ b/condarecipe9.2/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" build.py
+if errorlevel 1 exit 1

--- a/condarecipe9.2/bld.bat
+++ b/condarecipe9.2/bld.bat
@@ -1,2 +1,9 @@
 "%PYTHON%" build.py
 if errorlevel 1 exit 1
+
+:: copy nvvm and libdevice into the DLLs folder so numba can use them
+mkdir "%PREFIX%\DLLs"
+xcopy /s /y "%PREFIX%\Library\bin\nvvm*" "%PREFIX%\DLLs\"
+if errorlevel 1 exit 1
+xcopy /s /y "%PREFIX%\Library\bin\libdevice*" "%PREFIX%\DLLs\"
+if errorlevel 1 exit 1

--- a/condarecipe9.2/build.sh
+++ b/condarecipe9.2/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+python build.py

--- a/condarecipe9.2/meta.yaml
+++ b/condarecipe9.2/meta.yaml
@@ -1,0 +1,23 @@
+package:
+   name: cudatoolkit
+   version: 9.2
+
+build:
+  number: 0
+  script_env:
+    - NVTOOLSEXT_INSTALL_PATH
+
+requirements:
+  build:
+    - python >=3
+    - requests
+    - 7za # [win]
+    - conda
+    - pyyaml
+
+source:
+    path: ../scripts/
+
+test:
+  requires:
+    - numba

--- a/condarecipe9.2/run_test.py
+++ b/condarecipe9.2/run_test.py
@@ -1,0 +1,21 @@
+import sys
+import os
+from numba.cuda.cudadrv.libs import test, get_cudalib
+from numba.cuda.cudadrv.nvvm import NVVM
+
+
+def run_test():
+    if not test():
+        return False
+    nvvm = NVVM()
+    print("NVVM version", nvvm.get_version())
+    # check pkg version matches lib pulled in
+    gotlib = get_cudalib('cublas')
+    lookfor = os.environ['PKG_VERSION']
+    if sys.platform.startswith('win'):
+        # windows libs have no dot
+        lookfor = lookfor.replace('.', '')
+    return lookfor in gotlib
+
+
+sys.exit(0 if run_test() else 1)

--- a/condarecipe9.2/run_test.py
+++ b/condarecipe9.2/run_test.py
@@ -5,6 +5,11 @@ from numba.cuda.cudadrv.nvvm import NVVM
 
 
 def run_test():
+    # on windows only nvvm is available to numba
+    if sys.platform.startswith('win'):
+        nvvm = NVVM()
+        print("NVVM version", nvvm.get_version())
+        return nvvm.get_version() is not None
     if not test():
         return False
     nvvm = NVVM()
@@ -12,9 +17,6 @@ def run_test():
     # check pkg version matches lib pulled in
     gotlib = get_cudalib('cublas')
     lookfor = os.environ['PKG_VERSION']
-    if sys.platform.startswith('win'):
-        # windows libs have no dot
-        lookfor = lookfor.replace('.', '')
     return lookfor in gotlib
 
 

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -284,6 +284,7 @@ cu_92['md5_url'] = "http://developer.download.nvidia.com/compute/cuda/9.2/Prod2/
 cu_92['cuda_libraries'] = [
     'cudart',
     'cufft',
+    'cufftw',
     'cublas',
     'cusparse',
     'cusolver',
@@ -300,6 +301,8 @@ cu_92['cuda_libraries'] = [
     'nppisu',
     'nppitc',
     'npps',
+    'nvblas',
+    'nvgraph',
     'nvrtc',
     'nvrtc-builtins',
     'nvToolsExt',

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -350,6 +350,7 @@ cu_10['md5_url'] = "https://developer.download.nvidia.com/compute/cuda/10.0/Prod
 cu_10['cuda_libraries'] = [
     'cudart',
     'cufft',
+    'cufftw',
     'cublas',
     'cusparse',
     'cusolver',
@@ -366,6 +367,8 @@ cu_10['cuda_libraries'] = [
     'nppisu',
     'nppitc',
     'npps',
+    'nvblas',
+    'nvgraph',
     'nvrtc',
     'nvrtc-builtins',
     'nvToolsExt',

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -280,7 +280,7 @@ class Extractor(object):
 
     libdir = {'linux': 'lib',
               'osx': 'lib',
-              'windows': 'DLLs'}
+              'windows': 'Library/bin'}
 
     def __init__(self, version, ver_config, plt_config):
         """Initialise an instance:

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -280,7 +280,7 @@ cu_91['osx'] = {'blob': 'cuda_9.1.85_mac',
 cu_92 = config['9.2']
 cu_92['base_url'] = "https://developer.nvidia.com/compute/cuda/9.2/Prod2/"
 cu_92['installers_url_ext'] = 'local_installers/'
-cu_92['patch_url_ext'] = ''
+cu_92['patch_url_ext'] = 'patches/1/'
 cu_92['md5_url'] = "http://developer.download.nvidia.com/compute/cuda/9.2/Prod2/docs/sidebar/md5sum.txt"
 cu_92['cuda_libraries'] = [
     'cudart',
@@ -311,7 +311,7 @@ cu_92['cuda_libraries'] = [
 cu_92['libdevice_versions'] = ['10']
 
 cu_92['linux'] = {'blob': 'cuda_9.2.148_396.37_linux',
-                 'patches': [],
+                 'patches': ['cuda_9.2.148.1_linux'],
                  # need globs to handle symlinks
                  'cuda_lib_fmt': 'lib{0}.so*',
                  'nvtoolsext_fmt': 'lib{0}.so*',
@@ -320,7 +320,7 @@ cu_92['linux'] = {'blob': 'cuda_9.2.148_396.37_linux',
                  }
 
 cu_92['windows'] = {'blob': 'cuda_9.2.148_windows',
-                   'patches': [],
+                   'patches': ['cuda_9.2.148.1_windows'],
                    'cuda_lib_fmt': '{0}64_92.dll',
                    'nvtoolsext_fmt': '{0}64_1.dll',
                    'nvvm_lib_fmt': '{0}64_32_0.dll',
@@ -331,7 +331,7 @@ cu_92['windows'] = {'blob': 'cuda_9.2.148_windows',
                    }
 
 cu_92['osx'] = {'blob': 'cuda_9.2.148_mac',
-               'patches': [],
+               'patches': ['cuda_9.2.148.1_mac'],
                'cuda_lib_fmt': 'lib{0}.9.2.dylib',
                'nvtoolsext_fmt': 'lib{0}.1.dylib',
                'nvvm_lib_fmt': 'lib{0}.3.2.0.dylib',


### PR DESCRIPTION
Adds support for CUDA 9.2.  libfftw, libnvblas and libnvgraph are included in the cudatoolkit 9.2 package.

Includes commits from #9 which change the location of DLLs on Windows.