### PR TITLE
add micro version to cudatoolkit 10.0 package

### DIFF
--- a/condarecipe10.0/meta.yaml
+++ b/condarecipe10.0/meta.yaml
@@ -1,6 +1,7 @@
 package:
    name: cudatoolkit
-   version: 10.0
+   # match the package version to the libcudart.so version
+   version: 10.0.130
 
 build:
   number: 0

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -755,6 +755,10 @@ def _main():
 
     # package version decl must match cuda release version
     cu_version = os.environ['PKG_VERSION']
+    # keep only the major.minor version (10.0) if micro (10.0.130) is present
+    major_minor, micro = cu_version.rsplit('.', 1)
+    if '.' in major_minor:
+        cu_version = major_minor
 
     # get an extractor
     plat = getplatform()


### PR DESCRIPTION
Add the micro version to the cudatoolkit 10.0 version. This matches the version
of the libcudart.so library within the package.