### PR TITLE
cudatoolkit 10.1

### DIFF
--- a/condarecipe10.1/bld.bat
+++ b/condarecipe10.1/bld.bat
@@ -1,0 +1,9 @@
+"%PYTHON%" build.py
+if errorlevel 1 exit 1
+
+:: copy nvvm and libdevice into the DLLs folder so numba can use them
+mkdir "%PREFIX%\DLLs"
+xcopy /s /y "%PREFIX%\Library\bin\nvvm*" "%PREFIX%\DLLs\"
+if errorlevel 1 exit 1
+xcopy /s /y "%PREFIX%\Library\bin\libdevice*" "%PREFIX%\DLLs\"
+if errorlevel 1 exit 1

--- a/condarecipe10.1/build.sh
+++ b/condarecipe10.1/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+python build.py

--- a/condarecipe10.1/meta.yaml
+++ b/condarecipe10.1/meta.yaml
@@ -1,0 +1,24 @@
+package:
+   name: cudatoolkit
+   # match the package version to the libcudart.so version
+   version: 10.1.168
+
+build:
+  number: 0
+  script_env:
+    - NVTOOLSEXT_INSTALL_PATH
+
+requirements:
+  build:
+    - python >=3
+    - requests
+    - 7za # [win]
+    - conda
+    - pyyaml
+
+source:
+    path: ../scripts/
+
+test:
+  requires:
+    - numba

--- a/condarecipe10.1/run_test.py
+++ b/condarecipe10.1/run_test.py
@@ -1,0 +1,28 @@
+import sys
+import os
+from numba.cuda.cudadrv.libs import test, get_cudalib
+from numba.cuda.cudadrv.nvvm import NVVM
+
+
+def run_test():
+    # on windows only nvvm is available to numba
+    if sys.platform.startswith('win'):
+        nvvm = NVVM()
+        print("NVVM version", nvvm.get_version())
+        return nvvm.get_version() is not None
+    if not test():
+        return False
+    nvvm = NVVM()
+    print("NVVM version", nvvm.get_version())
+    # check pkg version matches lib pulled in
+    gotlib = get_cudalib('cublas')
+    # check cufft b/c cublas has an incorrect version in 10.1 update 1
+    gotlib = get_cudalib('cufft')
+    lookfor = os.environ['PKG_VERSION']
+    if sys.platform.startswith('win'):
+        # windows libs have no dot
+        lookfor = lookfor.replace('.', '')
+    return lookfor in gotlib
+
+
+sys.exit(0 if run_test() else 1)

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -683,7 +683,7 @@ class WindowsExtractor(Extractor):
                 store = os.path.join(tmpd, store_name)
                 os.mkdir(store)
                 for path, dirs, files in os.walk(extractdir):
-                    if 'jre' not in path:  # don't get jre dlls
+                    if 'jre' not in path and 'GFExperience' not in path:  # don't get jre or GFExperience dlls
                         for filename in fnmatch.filter(files, "*.dll"):
                             if not Path(os.path.join(
                                     store, filename)).is_file():

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -452,9 +452,9 @@ cu_101['linux'] = {'blob': 'cuda_10.1.168_418.67_linux.run',
                  'libdevice_lib_fmt': 'libdevice.{0}.bc'
                  }
 
-cu_101['windows'] = {'blob': 'cuda_10.1.168_425.325_windows',
+cu_101['windows'] = {'blob': 'cuda_10.1.168_425.25_windows.exe',
                    'patches': [],
-                   'cuda_lib_fmt': '{0}64_101*.dll',
+                   'cuda_lib_fmt': '{0}64_10*.dll',
                    'nvtoolsext_fmt': '{0}64_1.dll',
                    'nvvm_lib_fmt': '{0}64_33_0.dll',
                    'libdevice_lib_fmt': 'libdevice.{0}.bc',

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -437,10 +437,12 @@ cu_101['cuda_libraries'] = [
     'nvToolsExt',
     'nvblas',
     'nvgraph',
-    'nvjpeg',
     'nvrtc',
     'nvrtc-builtins',
 ]
+# nvjpeg is only available on linux
+if sys.platform.startswith('linux'):
+    cu_101['cuda_libraries'].append('nvjpeg')
 cu_101['libdevice_versions'] = ['10']
 
 cu_101['linux'] = {'blob': 'cuda_10.1.168_418.67_linux.run',


### PR DESCRIPTION
Recipe and modification to the build.py script needed for cudatoolkit 10.1 update 1.  
Two new libraries are included in this release, libcublasLt and libnvjpeg (linux only), both are distributable under the same license as other libraries in the previous release.
The linux run file requires that the extraction path be passed via the --installpath argument
The cublas library version is 10.2 not 10.1.